### PR TITLE
Передача дополнительных параметров

### DIFF
--- a/src/Esia/OpenId.php
+++ b/src/Esia/OpenId.php
@@ -87,7 +87,7 @@ class OpenId
      * @return string|false
      * @throws SignFailException
      */
-    public function buildUrl(string $state = null)
+    public function buildUrl(string $state = null, array $additionalParams = [])
     {
         $timestamp = $this->getTimeStamp();
         $state = $state ?? $this->buildState();
@@ -110,6 +110,10 @@ class OpenId
             'access_type' => $this->config->getAccessType(),
             'timestamp' => $timestamp,
         ];
+
+        if ($additionalParams) {
+            $params = array_merge($params, $additionalParams);
+        }
 
         $request = http_build_query($params);
 


### PR DESCRIPTION
Нужна возможность задать свои параметры.

Например, есть параметр person_filter, для фильтрации возможных для входа учеток. Передав в person_filter закодированную в base64 строку "conf_acc", разрешим входить только пользователям с подтвержденной учетной записью.

Также, для интеграции с цифровым профилем существует дополнительный параметр permissions, нужна возможность его задать.